### PR TITLE
Allow empty query param values

### DIFF
--- a/backbone.queryparams.js
+++ b/backbone.queryparams.js
@@ -258,7 +258,7 @@ function iterateQueryString(queryString, callback) {
   _.each(keyValues, function(keyValue) {
     var i = keyValue.indexOf('=');
     var arr = [keyValue.slice(0,i), keyValue.slice(i+1)];
-    if (arr.length > 1 && arr[1]) {
+    if (arr.length > 1) {
       callback(arr[0], arr[1]);
     }
   });


### PR DESCRIPTION
Any reason not to allow empty query params? I have a specific need for this in my app.

Example: `/foo?q=backbone&bar=`
Currently the `bar` just gets dropped, but i'd like `bar: ""` to show up in extracted parameters.
