### PR TITLE
Get backbone and underscore with require

### DIFF
--- a/backbone.queryparams.js
+++ b/backbone.queryparams.js
@@ -1,5 +1,13 @@
 (function(_, Backbone) {
 
+// Require Underscore and Backbone if there's a `require` function.
+// This makes `backbone.queryparam` work on the server or when using
+// `browserify`.
+if (typeof require !== 'undefined') {
+  _ = require('underscore');
+  Backbone = require('backbone');
+}
+
 var queryStringParam = /^\?(.*)/,
     optionalParam = /\((.*?)\)/g,
     namedParam    = /(\(\?)?:\w+/g,


### PR DESCRIPTION
This allows `backbone-query-parameters` to work properly on the server or when using browserify.
