### PR TITLE
fix IE issue "doesn't support 'replace'" for [] value

### DIFF
--- a/backbone.queryparams.js
+++ b/backbone.queryparams.js
@@ -232,7 +232,7 @@ _.extend(Backbone.Router.prototype, {
       } else if (_.isArray(_val)) {
         // arrays use Backbone.Router.arrayValueSplit separator
         var str = '';
-        for (var i in _val) {
+        for (var i = 0; i < _val.length; i++) {
           var param = this._toQueryParam(_val[i]);
           if (_.isBoolean(param) || param) {
             str += splitChar + encodeSplit(param);


### PR DESCRIPTION
fixes issue "Object doesn't Support Property or Method 'replace'" on IE 7 (and 8?) if Array is []. If using "for in" loop over [] in IE, then there is also an empty {} that is member of [](prototype):
for (var i in []) {
    // outputs {} on IE
    console.log(i);
}
