### PR TITLE
Check last param on false value instead of isUndefined

### DIFF
--- a/backbone.queryparams.js
+++ b/backbone.queryparams.js
@@ -119,7 +119,7 @@ _.extend(Backbone.Router.prototype, {
   _extractParameters: function(route, fragment) {
     var params = route.exec(fragment).slice(1),
         namedParams = {};
-    if (params.length > 0 && _.isUndefined(params[params.length - 1])) {
+    if (params.length > 0 && !params[params.length - 1]) {
       // remove potential invalid data from query params match
       params.splice(params.length - 1, 1);
     }


### PR DESCRIPTION
Last value of the array `var params = route.exec(fragment).slice(1)` has value '' (empty string) in ie8, and it has value `undefined` in other browsers. Therefore it is necessary to check for false value instead of isUndefined.
