### PR TITLE
Added backbone as a dependency in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,9 @@
   "name": "backbone-query-parameters",
   "version": "0.4.0",
   "main": "backbone.queryparams.js",
+  "dependencies": {
+    "backbone": ">= 1.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/jhudson8/backbone-query-parameters.git"


### PR DESCRIPTION
This PR fixes a problem I'm having when using [grunt-wiredep](https://github.com/stephenplusplus/grunt-wiredep) to inject bower packages into my code.
The missing dependency on backbone causes backbone.queryparams.js to be loaded before backbone.js