### PR TITLE
Fix pushState check

### DIFF
--- a/backbone.queryparams.js
+++ b/backbone.queryparams.js
@@ -29,7 +29,7 @@ _.extend(Backbone.History.prototype, {
     /*jshint eqnull:true */
     var root = '';
     if (fragment == null) {
-      if (this._hasPushState || !this._wantsHashChange || forcePushState) {
+      if (this._wantsPushState || !this._wantsHashChange || forcePushState) {
         fragment = this.location.pathname;
         if (this.root && this.root.length) {
           root = this.root.replace(trailingSlash, '');


### PR DESCRIPTION
Instead of checking if `pushState` is available, check if it's desired. To my knowledge, this fixes #104 issues with recent versions of Backbone.